### PR TITLE
feat: add cross-platform support for Mac

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
   // to make use of `TAURI_DEBUG` and other env variables
   // https://tauri.studio/v1/api/config#buildconfig.beforedevcommand
   envPrefix: ["VITE_", "TAURI_"],
+  esbuild: {
+    supported: {
+      'top-level-await': true
+    },
+  },
   build: {
     // Tauri supports es2021
     target: process.env.TAURI_PLATFORM === "windows" ? "chrome105" : "safari13",


### PR DESCRIPTION
a) Install the missing rust target for Apple silicon & Intel-based machines):
`rustup target add aarch64-apple-darwin`
`rustup target add x86_64-apple-darwin`
b) Build:
`tauri build --target aarch64-apple-darwin` (apple silicon)
`tauri build --target x86_64-apple-darwin` (intel)
`tauri build --target universal-apple-darwin` (both but larger)

*Double click `./src-tauri/target/aarch64-apple-darwin/release/TeyvatGuide` to run* (on apple silicon)