### PR TITLE
🐛 修复 macOS 27 下 SQLx 宏库加载失败

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -113,3 +113,7 @@ branch = "v2"
 git = "ssh://git@github.com/tauri-apps/plugins-workspace.git"
 branch = "v2"
 features = ["sqlite"]
+
+# macOS 27 暂时无法加载被 strip 的过程宏动态库
+[profile.release.package.sqlx-macros]
+strip = "none"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,10 @@ edition = "2024"
 name = "teyvat_guide_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+# macOS 27 暂时无法加载被 strip 的过程宏动态库
+[profile.release.package.sqlx-macros]
+strip = "none"
+
 [build-dependencies]
 tauri-build = { version = "2.6.2", features = [] }
 
@@ -113,7 +117,3 @@ branch = "v2"
 git = "ssh://git@github.com/tauri-apps/plugins-workspace.git"
 branch = "v2"
 features = ["sqlite"]
-
-# macOS 27 暂时无法加载被 strip 的过程宏动态库
-[profile.release.package.sqlx-macros]
-strip = "none"


### PR DESCRIPTION
## 变更

- 为 `sqlx-macros` 单独禁用 release strip
- 保持其他依赖及最终应用的 release 配置不变

## 原因

macOS 27 会拒绝加载 `LINKEDIT` 字符串表未按 8 字节对齐的动态库。当前 Rust/LLVM 在 strip 过程宏动态库时可能生成这种产物，导致 `sqlx_macros` 无法被 `dlopen`，并进一步引发 SQLx unresolved imports 编译错误。

该过程宏仅在编译期使用，不会进入最终应用，因此仅对它设置 `strip = "none"`。

相关上游问题：

- https://github.com/rust-lang/rust/issues/157750
- https://github.com/llvm/llvm-project/issues/203678

## 影响

- 修复 macOS 27 下的 release 构建
- 不影响应用运行逻辑、最终包体积及 SQLx 功能
- 其他平台仅会保留该编译期动态库的符号信息

## 验证

- `cargo clean -p sqlx-macros --release`
- `npm run build`
- Tauri `.app` 与 aarch64 `.dmg` 均成功生成
- 新生成的 `sqlx_macros` dylib：`stroff % 8 = 0`
